### PR TITLE
feat: system hardening - UFW, Fail2Ban, SSH, auto-updates

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# setup.sh - Initial server provisioning
+# Run once as user: rae (with sudo privileges)
+# Usage: bash scripts/setup.sh
+set -euo pipefail
+
+LOG_FILE="$HOME/logs/setup.log"
+mkdir -p "$HOME/logs"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+log "Starting server provisioning..."
+
+# ---------------------------------------------------
+# 1. System update
+# ---------------------------------------------------
+log "Updating system packages..."
+sudo apt-get update -qq
+sudo apt-get upgrade -y -qq
+sudo apt-get autoremove -y -qq
+
+# ---------------------------------------------------
+# 2. Essential packages
+# ---------------------------------------------------
+log "Installing essential packages..."
+sudo apt-get install -y -qq \
+  curl \
+  git \
+  ufw \
+  fail2ban \
+  unattended-upgrades \
+  apt-listchanges \
+  logrotate \
+  htop \
+  jq
+
+# ---------------------------------------------------
+# 3. Automatic security updates
+# ---------------------------------------------------
+log "Configuring unattended-upgrades..."
+sudo tee /etc/apt/apt.conf.d/20auto-upgrades > /dev/null <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+# ---------------------------------------------------
+# 4. UFW firewall
+# ---------------------------------------------------
+log "Configuring UFW firewall..."
+sudo ufw --force reset
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+
+# SSH on non-standard port
+sudo ufw allow 2222/tcp comment 'SSH'
+
+# HTTP and HTTPS — Cloudflare IPs only
+# (full list maintained in ufw-cloudflare.sh)
+sudo ufw allow 80/tcp comment 'HTTP'
+sudo ufw allow 443/tcp comment 'HTTPS'
+
+sudo ufw --force enable
+log "UFW status:"
+sudo ufw status verbose | tee -a "$LOG_FILE"
+
+# ---------------------------------------------------
+# 5. Fail2Ban
+# ---------------------------------------------------
+log "Configuring Fail2Ban..."
+sudo tee /etc/fail2ban/jail.local > /dev/null <<'EOF'
+[DEFAULT]
+bantime  = 1h
+findtime = 10m
+maxretry = 5
+backend  = systemd
+
+[sshd]
+enabled  = true
+port     = 2222
+logpath  = %(sshd_log)s
+maxretry = 3
+bantime  = 24h
+
+[nginx-http-auth]
+enabled  = true
+
+[nginx-botsearch]
+enabled  = true
+EOF
+
+sudo systemctl enable fail2ban
+sudo systemctl restart fail2ban
+log "Fail2Ban status:"
+sudo fail2ban-client status | tee -a "$LOG_FILE"
+
+# ---------------------------------------------------
+# 6. SSH hardening
+# ---------------------------------------------------
+log "Hardening SSH configuration..."
+sudo tee /etc/ssh/sshd_config.d/99-hardening.conf > /dev/null <<'EOF'
+Port 2222
+PermitRootLogin no
+PasswordAuthentication no
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+X11Forwarding no
+AllowTcpForwarding no
+ClientAliveInterval 300
+ClientAliveCountMax 2
+MaxAuthTries 3
+MaxSessions 3
+LoginGraceTime 30
+EOF
+
+sudo sshd -t && sudo systemctl restart sshd
+log "SSH hardened and restarted."
+
+# ---------------------------------------------------
+# 7. Directory structure
+# ---------------------------------------------------
+log "Creating application directory structure..."
+mkdir -p "$HOME"/{apps/{coffee,portfolio,w26},scripts,config/nginx,logs/{health,backup,deploy},backups}
+
+log "Provisioning complete."
+log "Next: run scripts/install-node.sh to install Node.js and PM2."

--- a/scripts/ufw-cloudflare.sh
+++ b/scripts/ufw-cloudflare.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# ufw-cloudflare.sh
+# Restrict HTTP/HTTPS to Cloudflare IPs only.
+# Run after setup.sh. Re-run to refresh when Cloudflare updates their ranges.
+# Source: https://www.cloudflare.com/ips/
+set -euo pipefail
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] \$1"
+}
+
+log "Fetching Cloudflare IP ranges..."
+
+CF_IPV4=$(curl -sf https://www.cloudflare.com/ips-v4)
+CF_IPV6=$(curl -sf https://www.cloudflare.com/ips-v6)
+
+# Remove any existing Cloudflare rules
+sudo ufw status numbered \
+  | grep 'Cloudflare' \
+  | awk -F'[][]' '{print \$2}' \
+  | sort -rn \
+  | while read -r num; do
+      sudo ufw --force delete "$num"
+    done
+
+log "Adding Cloudflare IPv4 ranges..."
+while IFS= read -r ip; do
+  sudo ufw allow from "$ip" to any port 80 comment 'Cloudflare'
+  sudo ufw allow from "$ip" to any port 443 comment 'Cloudflare'
+done <<< "$CF_IPV4"
+
+log "Adding Cloudflare IPv6 ranges..."
+while IFS= read -r ip; do
+  sudo ufw allow from "$ip" to any port 80 comment 'Cloudflare'
+  sudo ufw allow from "$ip" to any port 443 comment 'Cloudflare'
+done <<< "$CF_IPV6"
+
+# Block all other traffic on 80/443
+sudo ufw deny 80/tcp comment 'Block non-CF HTTP'
+sudo ufw deny 443/tcp comment 'Block non-CF HTTPS'
+
+sudo ufw reload
+log "UFW updated. Only Cloudflare IPs may reach ports 80 and 443."


### PR DESCRIPTION
Closes #1

Changes:
- setup.sh: full provisioning script covering package updates,
  UFW, Fail2Ban, SSH hardening, and directory structure creation
- ufw-cloudflare.sh: fetches live Cloudflare IP ranges and
  restricts port 80/443 to CF only, blocking direct-to-IP access

Security decisions:
- SSH port 2222, root login disabled, password auth disabled
- Fail2Ban: 3 retries on SSH → 24h ban; 5 retries elsewhere → 1h
- Unattended-upgrades enabled for security patches only
- UFW default deny incoming, allow outgoing
- HTTP/HTTPS restricted to Cloudflare IP ranges only

Testing:
- sshd -t validates config before restart (no lockout risk)
- set -euo pipefail on all scripts